### PR TITLE
🛠️ Refactor: Improve store syntax and implement centralized error reporting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "mathwars",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -15,28 +15,25 @@
 
     console.log('idUsuario', idUsuario)
 
-    let doomfireDecay;
-    doomfireStore.decay.subscribe((v) => doomfireDecay = v)
-    let doomfireWind;
-    doomfireStore.wind.subscribe((v) => doomfireWind = v)
+    const doomfireDecay = doomfireStore.decay;
+    const doomfireWind = doomfireStore.wind;
 
-    let doomfireContainerRef;
-    let musicRef;
+    let doomfireContainerRef: HTMLDivElement;
+    let musicRef: HTMLAudioElement;
 
-    let currentLocation;
-    locationStore.subscribe(href => {currentLocation = href; handleMusicStateChange()})
-
-    let isUserInteracted = false;
-    isUserInteractedStore.subscribe((v) => {isUserInteracted = v; handleMusicStateChange()})
-
-    console.log(currentLocation);
+    $: console.log($locationStore);
+    $: {
+        $locationStore;
+        $isUserInteractedStore;
+        handleMusicStateChange();
+    }
     
     function handleMusicStateChange() {
         if (!musicRef) {
             return;
         }
-        if (isUserInteracted) {
-            if (currentLocation.pathname.startsWith("/play")) {
+        if ($isUserInteractedStore) {
+            if ($locationStore.pathname.startsWith("/play")) {
                 let i = 0
                 const interval = setInterval(() => {
                     if (i >= 100) {
@@ -75,30 +72,30 @@
             on:render={() => console.log('doomfire render')}
             on:resize={() => console.log('doomfire resize')}
             containerRef={doomfireContainerRef}
-            decay={doomfireDecay}
-            wind={doomfireWind}
+            decay={$doomfireDecay}
+            wind={$doomfireWind}
         />
     <!-- {/if} -->
 </div>
 <audio bind:this={musicRef} id="audio-intro" src="/intro.m4a" loop></audio>
-<main on:click={handleUserInteraction} on:tap={handleUserInteraction} on:keypress={noop}>
+<main on:click={handleUserInteraction} on:keypress={noop}>
     <section class="mathwars-page-section">
         <MathwarsLogo on:click={handleJump("/")} />
-        {#if !isUserInteracted}
+        {#if !$isUserInteractedStore}
             <p class="mathwars-text-description">Clique em algum lugar para iniciar</p>
-        {:else if currentLocation.pathname === "/"}
+        {:else if $locationStore.pathname === "/"}
             <MainPage/>
-        {:else if currentLocation.pathname === "/options"}
+        {:else if $locationStore.pathname === "/options"}
             <OptionsPage/>
-        {:else if currentLocation.pathname === '/play/quick'}
+        {:else if $locationStore.pathname === '/play/quick'}
             <QuickMatch/>
-        {:else if currentLocation.pathname === '/play/problemgen'}
+        {:else if $locationStore.pathname === '/play/problemgen'}
             <Problemgen/>
-        {:else if currentLocation.pathname === '/play/stats'}
+        {:else if $locationStore.pathname === '/play/stats'}
             <PlayStatsPage/>
-        {:else if currentLocation.pathname === '/play/questiongen'}
+        {:else if $locationStore.pathname === '/play/questiongen'}
             <Questiongen/>
-        {:else if currentLocation.pathname === "/doomfire"}
+        {:else if $locationStore.pathname === "/doomfire"}
             <DoomfireControl />
         {:else}
             <p class="mathwars-text-description">* Rota não encontrada *</p>

--- a/src/lib/ProgressBar.svelte
+++ b/src/lib/ProgressBar.svelte
@@ -4,7 +4,7 @@
     export let color = 'white';
 </script>
 
-<div class="progress-bar" style={`width: ${progress}%; background-color: ${color}`}/>
+<div class="progress-bar" style={`width: ${progress}%; background-color: ${color}`}></div>
 
 <style>
     .progress-bar {

--- a/src/lib/errorReporting.ts
+++ b/src/lib/errorReporting.ts
@@ -1,0 +1,6 @@
+export function reportError(error: any, context?: Record<string, any>) {
+    // A centralized error reporting function.
+    // Funnels unexpected errors through here.
+    console.error('[Error Reporter]', error, context);
+    // Here we would potentially call Sentry.captureException(error, { extra: context }) if it were installed
+}

--- a/src/lib/ntfy.ts
+++ b/src/lib/ntfy.ts
@@ -1,3 +1,4 @@
+import { reportError } from "./errorReporting";
 import { idUsuario } from "./user";
 
 export function getNtfyTopic(topic: string) {
@@ -27,7 +28,7 @@ export function getNtfyTopic(topic: string) {
                     console.log("NTFY", text)
                     callback(text)
                 } catch (e) {
-                    console.error(e)
+                    reportError(e, { messageData: message })
                 }
             }
         })

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { mount } from 'svelte'
 import App from './App.svelte'
 
 const app = mount(App, {
-  target: document.getElementById('app')
+  target: document.getElementById('app')!
 })
 
 export default app

--- a/src/pages/DoomfireControl.svelte
+++ b/src/pages/DoomfireControl.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
     import doomfireStore from '../stores/doomfire';
-    let doomfireDecay;
-    doomfireStore.decay.subscribe((v) => doomfireDecay = v)
-    let doomfireWind;
-    doomfireStore.wind.subscribe((v) => doomfireWind = v)
-    $: doomfireStore.decay.set(doomfireDecay)
-    $: doomfireStore.wind.set(doomfireWind)
+    const doomfireWind = doomfireStore.wind;
+    const doomfireDecay = doomfireStore.decay;
 </script>
 
 <svelte:head>
@@ -14,11 +10,11 @@
 <section class="doomfire-control">
     <div>
         <p>Vento: </p>
-        <input type='number' step="0.1" bind:value={doomfireWind}>
+        <input type='number' step="0.1" bind:value={$doomfireWind}>
     </div>
     <div>
         <p>Decaimento: </p>
-        <input type="number" bind:value={doomfireDecay}>
+        <input type="number" bind:value={$doomfireDecay}>
     </div>
 </section>
 

--- a/src/pages/MainPage.svelte
+++ b/src/pages/MainPage.svelte
@@ -1,13 +1,10 @@
 <script lang='ts'>
   import { usernameStore } from "../lib/user";
   import { handleJump } from "../stores/location";
-
-  let username;
-  usernameStore.subscribe(u => username = u)
 </script>
 <svelte:head>
     <title>Página Inicial - MathWars</title>
 </svelte:head>
-<h1 class="mathwars-text-description">Bem vindo/a, {username}</h1>
+<h1 class="mathwars-text-description">Bem vindo/a, {$usernameStore}</h1>
 <button class="mathwars-button" on:click={handleJump("/play/quick")}>Jogo rápido</button>
 <button class="mathwars-button" on:click={handleJump("/options")}>Opções</button>

--- a/src/pages/OptionsPage.svelte
+++ b/src/pages/OptionsPage.svelte
@@ -1,11 +1,6 @@
 <script lang='ts'>
   import { handleJump } from "../stores/location";
   import { changeName, usernameStore } from "../lib/user";
-
-
-    let username;
-    usernameStore.subscribe(u => username = u)
-
 </script>
 
 
@@ -14,7 +9,7 @@
 </svelte:head>
 
 <h1 class="mathwars-text-description">Opções</h1>
-<button class="mathwars-button" on:click={changeName}>Alterar seu nome (atual: '{username}')</button>
+<button class="mathwars-button" on:click={changeName}>Alterar seu nome (atual: '{$usernameStore}')</button>
 <button class="mathwars-button" on:click={handleJump("/doomfire")}>Brincar com fogo</button>
 <button class="mathwars-button" on:click={handleJump("/play/problemgen")}>Gerar problemas</button>
 <button class="mathwars-button" on:click={handleJump("/play/questiongen")}>Questões infinitas</button>

--- a/src/pages/PlayStatsPage.svelte
+++ b/src/pages/PlayStatsPage.svelte
@@ -10,8 +10,12 @@ onMount(() => {
     if (!url.searchParams.has('state')) {
         alert('Esta página não foi feita para ser usada desta forma. Indo para a página inicial...')
         history.pushState({}, '', '/')
+    } else {
+        const stateParam = url.searchParams.get('state')
+        if (stateParam) {
+            state = JSON.parse(atob(stateParam))
+        }
     }
-    state = JSON.parse(atob(url.searchParams.get('state')))
     console.log(state)
 })
 

--- a/src/pages/QuickMatch.svelte
+++ b/src/pages/QuickMatch.svelte
@@ -14,22 +14,19 @@
     $: ops = new Set(opsTxt.split('').filter((item) => "+-/*".includes(item))) as Set<Problem['op']>
     $: opsArg = [...ops].length == 0 ? undefined : ops
 
-    let username;
-    usernameStore.subscribe((u) => username = u)
-
     onMount(() => {
         const url = new URL(window.location.href)
         if (url.searchParams.has('maxNumber')) {
-            const n = parseInt(url.searchParams.get('maxNumber'))
+            const n = parseInt(url.searchParams.get('maxNumber') || "")
             if (!isNaN(n)) {
                 maxNumber = n
             }
         }
         if (url.searchParams.has('ops')) {
-            opsTxt = url.searchParams.get('ops').replace(' ', '+')
+            opsTxt = (url.searchParams.get('ops') || "").replace(' ', '+')
         }
         if (url.searchParams.has('plays')) {
-            const n = parseInt(url.searchParams.get('plays'))
+            const n = parseInt(url.searchParams.get('plays') || "")
             if (!isNaN(n)) {
                 jogadas = n
             }
@@ -52,8 +49,8 @@
         console.log(respostas.length)
         if (respostas.length >= jogadas) {
             console.log('mais respostas que jogadas')
-            const id = idUsuario;
-            const name = username;
+            const id = idUsuario || "unknown";
+            const name = $usernameStore;
             const result: Record<string, Match> = {
                 [id]: {
                     name,
@@ -74,7 +71,7 @@
         problem = nextProblem()
     }
 
-    function handleCopyMatchLink(e) {
+    function handleCopyMatchLink(e: MouseEvent) {
         e.preventDefault()
         let url = new URL(window.location.href)
         url.searchParams.set('maxNumber', String(maxNumber))


### PR DESCRIPTION
This pull request focuses on improving the internal structure and reducing complexity by leveraging Svelte's reactive `$store` syntax and standardizing error handling.

### Justification
- **Single Responsibility Principle & Abstraction (Extraction):** As described by Martin in *Clean Code*, centralizing error reporting into `src/lib/errorReporting.ts` abstracts the underlying logging mechanism from business logic (like in `src/lib/ntfy.ts`). This ensures all unexpected errors funnel through a single point, satisfying global rules and making it trivial to swap logging backends (e.g., adding Sentry) later.
- **Cognitive Load & Boilerplate Reduction:** Using idiomatic Svelte `$storeName` syntax instead of manual `.subscribe()` calls directly reduces boilerplate and mitigates implicit `any` type issues, as encouraged by the project's Svelte conventions.

### Assumptions
- I assume replacing manual `.subscribe()` in `App.svelte` and re-attaching the side-effect (via reactive `$: { $locationStore; $isUserInteractedStore; handleMusicStateChange(); }`) perfectly mirrors the intended runtime behavior without regressions.
- Sentry or another advanced tracker is not strictly required yet; logging via a structured function to `console.error` satisfies the immediate "centralized" requirement.

### Alternatives Not Chosen
- Adding Sentry packages: Deferred since it expands scope beyond internal structure improvements.
- Fixing all a11y warnings (`<main>` elements with `on:click`): I focused strictly on TypeScript implicit `any` errors, component store syntax, and error reporting, leaving a11y for a dedicated UI/UX pass to avoid bloating this PR's diff size.

### How To Pivot
If the reactive side-effect in `App.svelte` feels too indirect, the smallest concrete change is to revert `App.svelte` back to manual `.subscribe()` calls while retaining the typed `HTMLDivElement` / `HTMLAudioElement` fixes.

### Next Knobs
1. Edit `src/lib/errorReporting.ts` to integrate Sentry or a specific telemetry service.
2. Address the leftover a11y warnings related to `on:click` handlers on `main`/`div` elements in `App.svelte`.
3. Standardize URL parsing across pages to handle missing search parameters more robustly.

---
*PR created automatically by Jules for task [12957188974884195795](https://jules.google.com/task/12957188974884195795) started by @lucasew*