### PR TITLE
🛡️ Sentinel: [Medium] Fix ignored/swallowed errors with centralized error reporting

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,1 @@
+- 2024-03-10: [Medium] Ignored/swallowed errors without using centralized error reporting mechanism.

--- a/src/lib/errorReporting.ts
+++ b/src/lib/errorReporting.ts
@@ -1,0 +1,4 @@
+export function reportError(error: unknown, context?: Record<string, any>) {
+    console.error("Centralized Error Report:", error, context);
+    // If Sentry was available, it would be called here: Sentry.captureException(error, { extra: context })
+}

--- a/src/lib/ntfy.ts
+++ b/src/lib/ntfy.ts
@@ -1,15 +1,23 @@
 import { idUsuario } from "./user";
+import { reportError } from "./errorReporting";
 
 export function getNtfyTopic(topic: string) {
     console.log("NTFY", topic)
     async function send(text: string) {
-        const res = await fetch(`https://ntfy.sh/${topic}`, {
-            method: 'POST',
-            body: JSON.stringify({
-                text,
-                uuid: idUsuario
-            })
-        })
+        try {
+            const res = await fetch(`https://ntfy.sh/${topic}`, {
+                method: 'POST',
+                body: JSON.stringify({
+                    text,
+                    uuid: idUsuario
+                })
+            });
+            if (!res.ok) {
+                reportError(new Error(`Failed to send message: ${res.statusText}`), { topic, text });
+            }
+        } catch (e) {
+            reportError(e, { context: "ntfy send message", topic, text });
+        }
     }
     async function subscribe(callback: (message: string) => any) {
         const wsUrl = `ws://ntfy.sh/${topic}/ws`;
@@ -27,7 +35,7 @@ export function getNtfyTopic(topic: string) {
                     console.log("NTFY", text)
                     callback(text)
                 } catch (e) {
-                    console.error(e)
+                    reportError(e, { context: "ntfy websocket message handler", rawMessage: message });
                 }
             }
         })


### PR DESCRIPTION
### Vulnerability
Medium severity: Ignored/swallowed errors and unhandled promise rejections without centralized error reporting, hiding issues and preventing appropriate alerting.

### Impact
Network failures on `send()` and JSON parsing failures on `subscribe()` were either failing silently or just dumping to `console.error` directly. This makes troubleshooting difficult and masks potentially deeper issues.

### Fix
Created a centralized `reportError` function in `src/lib/errorReporting.ts` that acts as a sink for all uncaught/unhandled errors, ready to be wired up to an external service like Sentry. Updated `ntfy.ts` to capture the potential errors and report them correctly with context.

### Verification
Ran `bun run check` and verified no new type check errors were introduced by this change.

### Assumptions
- A generic wrapper for error reporting can be stubbed out with `console.error` and an inline comment for future Sentry expansion.
- Failing a notification send quietly without breaking the main app loop is intended behavior (as long as it is tracked now).

### Alternatives Not Chosen
- Wrapping the entire file contents in an error boundary.

### How To Pivot
If `errorReporting.ts` should be placed elsewhere, it can be relocated and the import paths updated. If another backend is preferred, you can swap out the implementation of `reportError` in `errorReporting.ts`.

### Next Knobs
- Adjust `errorReporting.ts` to actually call Sentry.
- Search for other loose instances of `console.error` across the codebase.
- Refine what metadata is included in `context` parameter.

---
*PR created automatically by Jules for task [11948730253526700316](https://jules.google.com/task/11948730253526700316) started by @lucasew*